### PR TITLE
Use of "java.util.Objects" in JBPMConfiguration requires Java 7+

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -80,8 +80,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Minor update to POM in "camel-jbpm-component" to specify use of Java 7.
